### PR TITLE
Update method doesMethodChangeDataOrBehavior

### DIFF
--- a/main/br/ufrj/cos/pinel/ligeiro/Core.java
+++ b/main/br/ufrj/cos/pinel/ligeiro/Core.java
@@ -399,7 +399,7 @@ public class Core
 													int i = 0;
 													for (Parameter param : method.getParameters())
 													{
-														if (i < params.length && !param.getType().equals(params[i]))
+														if (i < params.length && !param.getType().equals(params[i].trim()))
 														{
 															match = false;
 															break;


### PR DESCRIPTION
Necessário fazer o trim do parâmetro pois em algum casos o valor do parâmetro pode conter espaços em branco. Levando o programa a não encontrar o método que deveria ser encontrado.
